### PR TITLE
config: border radius

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -48,7 +48,7 @@ const Badge: FC<BadgeProps> = ({
     <div
       className={cx(
         className,
-        "okd-inline-flex okd-items-center okd-py-0.5 okd-font-medium okd-rounded",
+        "okd-inline-flex okd-items-center okd-py-0.5 okd-font-medium okd-rounded-sm",
         {
           "okd-px-1.5 okd-text-xs": size === "sm",
           "okd-px-2 okd-text-sm": size === "lg",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -54,7 +54,7 @@ const Button: FC<ButtonProps> = ({ children, block, disabled, type }) => {
     <button
       type="button"
       className={cx(
-        "okd-inline-flex okd-items-center okd-justify-center okd-px-4 okd-py-2 okd-text-sm okd-font-medium border okd-rounded-md okd-shadow-sm focus:okd-outline-none focus:okd-ring-2 focus:okd-ring-offset-2 dark:okd-ring-offset-gray-900",
+        "okd-inline-flex okd-items-center okd-justify-center okd-px-4 okd-py-2 okd-text-sm okd-font-medium border okd-rounded okd-shadow-sm focus:okd-outline-none focus:okd-ring-2 focus:okd-ring-offset-2 dark:okd-ring-offset-gray-900",
         {
           "hover:okd-border-brand-500 hover:okd-text-brand-500 focus:okd-ring-brand-500 dark:hover:okd-bg-brand-500":
             type === "default",

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -41,7 +41,7 @@ const Dropdown: FC<DropdownProps> = ({
           <Popover.Button
             ref={triggerButtonRef}
             className={classNames(
-              "okd-inline-flex okd-items-center okd-p-2 okd-text-sm okd-font-medium okd-rounded-md focus:okd-outline-none focus:okd-ring-2 focus:okd-ring-offset-2 focus:okd-ring-brand-500 dark:okd-ring-offset-gray-900",
+              "okd-inline-flex okd-items-center okd-p-2 okd-text-sm okd-font-medium okd-rounded focus:okd-outline-none focus:okd-ring-2 focus:okd-ring-offset-2 focus:okd-ring-brand-500 dark:okd-ring-offset-gray-900",
               open
                 ? "okd-bg-gray-100 okd-text-gray-900 dark:okd-bg-gray-700 dark:okd-text-gray-50 focus:okd-ring-0 focus:okd-ring-transparent"
                 : "okd-text-gray-700 hover:okd-bg-gray-50 dark:hover:okd-bg-gray-800 dark:okd-text-gray-200"
@@ -62,7 +62,7 @@ const Dropdown: FC<DropdownProps> = ({
             leaveTo="okd-transform okd-opacity-0 okd-scale-95"
           >
             <Popover.Panel className="okd-absolute okd-z-10 okd-w-64 okd-mt-2 okd-origin-top okd--translate-x-1/2 left-1/2 sm:origin-tookd-p-right sm:left-auto sm:translate-x-0 sm:-right-1">
-              <div className="okd-overflow-hidden bg-white okd-rounded-lg okd-shadow-lg okd-ring-1 okd-ring-black/5 dark:okd-bg-gray-900 dark:okd-ring-white/20">
+              <div className="bg-white okd-overflow-hidden okd-rounded-lg okd-shadow-lg okd-ring-1 okd-ring-black/5 dark:okd-bg-gray-900 dark:okd-ring-white/20">
                 {children}
               </div>
             </Popover.Panel>

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -53,7 +53,7 @@ const Input: FC<InputProps> = ({
         }}
         type="text"
         className={cx(
-          "okd-block okd-w-full okd-pr-10 okd-bg-gray-50 okd-form-input sm:okd-text-sm okd-rounded-md dark:okd-bg-black/50",
+          "okd-block okd-w-full okd-pr-10 okd-bg-gray-50 okd-form-input sm:okd-text-sm okd-rounded dark:okd-bg-black/50",
           error
             ? "okd-border-red-300 okd-text-red-900 okd-placeholder-red-300 focus:okd-outline-none focus:okd-ring-red-500 focus:okd-border-red-500 dark:okd-text-red-300"
             : "okd-text-gray-700 okd-placeholder-gray-400 focus:okd-ring-brand-500 focus:okd-border-brand-500 okd-border-gray-200 dark:okd-border-gray-600 dark:okd-placeholder-gray-500 dark:okd-text-gray-200"

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -216,7 +216,7 @@ const Sidebar: FC<SidebarProps> = ({
                                 isActive
                                   ? "okd-bg-gray-200 okd-text-gray-900"
                                   : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                                "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                                "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                               )}
                               aria-current={isActive ? "page" : undefined}
                             >
@@ -271,7 +271,7 @@ const Sidebar: FC<SidebarProps> = ({
                               isActive
                                 ? "okd-bg-gray-200 okd-text-gray-900"
                                 : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                              "group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                              "group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                             )}
                             aria-current={isActive ? "page" : undefined}
                           >
@@ -321,7 +321,7 @@ const Sidebar: FC<SidebarProps> = ({
                             isActive
                               ? "okd-bg-gray-200 okd-text-gray-900"
                               : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                            "group justify-between flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                            "group justify-between flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                           )}
                           aria-current={isActive ? "page" : undefined}
                         >
@@ -414,7 +414,7 @@ const Sidebar: FC<SidebarProps> = ({
                             isActive
                               ? "okd-bg-gray-200 okd-text-gray-900"
                               : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                            "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                            "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                           )}
                           aria-current={isActive ? "page" : undefined}
                         >
@@ -484,7 +484,7 @@ const Sidebar: FC<SidebarProps> = ({
                           isActive
                             ? "okd-bg-gray-200 okd-text-gray-900"
                             : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                          "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                          "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                         )}
                         aria-current={isActive ? "page" : undefined}
                       >
@@ -545,7 +545,7 @@ const Sidebar: FC<SidebarProps> = ({
                         isActive
                           ? "okd-bg-gray-200 okd-text-gray-900"
                           : "okd-text-gray-600 hover:okd-text-gray-900 hover:okd-bg-gray-100",
-                        "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded-md"
+                        "okd-group okd-justify-between okd-flex okd-items-center okd-px-2 okd-py-2 okd-text-sm okd-font-medium okd-rounded"
                       )}
                       aria-current={isActive ? "page" : undefined}
                     >

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -21,7 +21,7 @@
 @layer components {
   .tooltip {
     /* the !important is must-have, go to https://github.com/wwayne/react-tooltip for more info */
-    @apply okd-px-2 okd-py-1 okd-text-xs okd-rounded-md okd-shadow okd-transition !important;
+    @apply okd-px-2 okd-py-1 okd-text-xs okd-rounded okd-shadow okd-transition !important;
 
     &.type-dark {
       @apply okd-bg-gray-700 okd-text-gray-50 !important;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,12 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
-const { colors } = require('./src/components/utils/tailwind');
+const { colors } = require("./src/components/utils/tailwind");
 
 module.exports = {
   mode: "jit",
-  prefix: 'okd-',
+  prefix: "okd-",
   purge: {
-    mode: 'all',
-    content: ["./src/**/*.{js,jsx,ts,tsx}"]
+    mode: "all",
+    content: ["./src/**/*.{js,jsx,ts,tsx}"],
   },
   darkMode: "media", // or 'media' or 'class'
   theme: {
@@ -22,6 +22,13 @@ module.exports = {
           "WenQuanYi Micro Hei",
         ],
       },
+    },
+    borderRadius: {
+      none: "0",
+      sm: "0.375rem",
+      DEFAULT: "0.75rem",
+      lg: "1.5rem",
+      full: "9999px",
     },
   },
   variants: {


### PR DESCRIPTION
经确认，未来 UI 组件的圆角值仅存在以下可能性：`0` `6px` `12px` `24px` `full`。我调整了一下 tailwind 的配置，对应的 class 为：
- `okd-rounded-none` – 0px
- `okd-rounded-sm` – 6px
- `okd-rounded` – 12px (Default)
- `okd-rounded-lg` – 24px
- `okd-rounded-full` – full

请参与组件开发的各位知悉哈，Figma 的组件上也已经调整相关参数。